### PR TITLE
added '--config' parameter 

### DIFF
--- a/croncoat/cc/mailbackend.py
+++ b/croncoat/cc/mailbackend.py
@@ -12,21 +12,23 @@ import os
 import ConfigParser
 
 class MailBackend(object):
-    def __init__(self, scriptname):
+    def __init__(self, scriptpath):
         self.smtp = SMTP_SSL()
         self.cfg = ConfigParser.SafeConfigParser()
-        fname = os.path.expanduser('~/.%s.ini' % scriptname)
-        self.cfg.read(fname)
+        fname = os.path.realpath(scriptpath)
 
-#         print(self.cfg.sections())
-        #  print(self.cfg.options('Mail'))
-        self.server = self.cfg.get('Mail', 'smtpserver')
-        self.port = self.cfg.get('Mail', 'smtpport')
-        self.mailuser = self.cfg.get('Mail','user')
-        self.mailpass = self.cfg.get('Mail','pass')
-        self.fromaddr = self.cfg.get('Mail', 'fromaddr')
-        self.loggedin = False
-        
+        try:
+            self.cfg.read(fname)
+            self.server = self.cfg.get('Mail', 'smtpserver')
+            self.port = self.cfg.get('Mail', 'smtpport')
+            self.mailuser = self.cfg.get('Mail','user')
+            self.mailpass = self.cfg.get('Mail','pass')
+            self.fromaddr = self.cfg.get('Mail', 'fromaddr')
+            self.loggedin = False
+        except Exception, e:
+            import sys
+            sys.exit( "%s appears not to be an .ini file with the appropriate sections.\n \
+Call 'croncoat --ini' for an example layout of the .ini file" %scriptpath )
 
     def sendmail(self, emailMsg):
         if(not self.loggedin):

--- a/croncoat/scripts/ccscript.py
+++ b/croncoat/scripts/ccscript.py
@@ -17,6 +17,7 @@ __scriptname__ = 'croncoat'
 #  import re
 import argparse
 import sys
+import os
 from croncoat.cc.cronwrapper import CronWrapper
 
 class MyParser(argparse.ArgumentParser):
@@ -75,6 +76,11 @@ def main(input_args=None):
                         help='Print the configuration file format. '  
                         )
 
+    parser.add_argument('--config', default=False,
+                        help='use an .ini file with custom name and path  '
+                        '(not the default .croncoat.ini in users\' home directory'  
+                        )
+
     parser.add_argument('-v', '--verbose',
                         nargs='?', default=False,
                         help='Will send an email / print to stdout even on successful run.')
@@ -93,6 +99,14 @@ def main(input_args=None):
         parser.print_help()
         sys.exit(1)
     else:
-        cwrap = CronWrapper(sys_args, __scriptname__)
-        cwrap.run()
+        if sys_args.config is not False:
+            configpath = os.path.realpath(sys_args.config)
+        else: # default 
+            configpath = os.path.expanduser("'~/.%s.ini" % __scriptname__)
+        if os.path.exists(configpath) and os.path.isfile(configpath): 
+            cwrap = CronWrapper(sys_args, configpath)
+            cwrap.run()
+        else:
+            sys.exit("no config file detected at %s" %configpath)
+
 


### PR DESCRIPTION
added '--config' parameter to add an .ini file with any arbitrary name or location; has fallback to the legacy .croncoat.ini file in users' home dir
