### PR TITLE
added sendmail fallback

### DIFF
--- a/croncoat/cc/cronwrapper.py
+++ b/croncoat/cc/cronwrapper.py
@@ -49,11 +49,12 @@ class CronWrapper(object):
         return (
 """#example format for ~/.%s.ini (don't use quotes!)
 [Mail]
-smtpserver=
+smtpserver=mailtrap.io
 smtpport=
 user=
 pass=
 fromaddr=
+use_sendmailfallback=True
 """.format(scriptname))
     
     @staticmethod

--- a/croncoat/cc/cronwrapper.py
+++ b/croncoat/cc/cronwrapper.py
@@ -55,6 +55,7 @@ user=
 pass=
 fromaddr=
 use_sendmailfallback=True
+log=/var/log/croncoat.log
 """.format(scriptname))
     
     @staticmethod

--- a/croncoat/cc/mailbackend.py
+++ b/croncoat/cc/mailbackend.py
@@ -31,14 +31,20 @@ class MailBackend(object):
 Call 'croncoat --ini' for an example layout of the .ini file" %scriptpath )
 
     def sendmail(self, emailMsg):
-        if(not self.loggedin):
-            emailMsg['From']=self.fromaddr
-            
-            self.smtp.connect(self.server, self.port)
-            self.smtp.login(self.mailuser, self.mailpass)
-            self.loggedin = True
-
-        self.smtp.sendmail(emailMsg['From'], emailMsg['To'], emailMsg.as_string())
+        try:
+            if(not self.loggedin):
+                emailMsg['From']=self.fromaddr
+                self.smtp.connect(self.server, self.port)
+                self.smtp.login(self.mailuser, self.mailpass)
+                self.loggedin = True
+            self.smtp.sendmail(emailMsg['From'], emailMsg['To'], emailMsg.as_string())
+        except Exception, e:
+            print "sendmail exception: %s" %str(e)
+            if self.cfg.get('Mail', 'use_sendmailfallback', False):
+                from subprocess import Popen, PIPE
+                sm_proc = Popen(["/usr/sbin/sendmail", "-t", "-oi"], stdin=PIPE)
+                sm_proc.communicate(emailMsg.as_string())
+                print "(sendmail fallback used)"
 
     def __exit__(self):
         print("exiting MailBackend")

--- a/croncoat/cc/mailbackend.py
+++ b/croncoat/cc/mailbackend.py
@@ -12,11 +12,13 @@ import os
 import ConfigParser
 
 class MailBackend(object):
+
     def __init__(self, scriptpath):
         self.smtp = SMTP_SSL()
-        self.cfg = ConfigParser.SafeConfigParser()
+        default_configvalues = {'use_sendmailfallback': False,
+                                'sendmail_path': '/usr/sbin/sendmail'}
+        self.cfg = ConfigParser.SafeConfigParser(defaults=default_configvalues)
         fname = os.path.realpath(scriptpath)
-
         try:
             self.cfg.read(fname)
             self.server = self.cfg.get('Mail', 'smtpserver')
@@ -30,6 +32,7 @@ class MailBackend(object):
             sys.exit( "%s appears not to be an .ini file with the appropriate sections.\n \
 Call 'croncoat --ini' for an example layout of the .ini file" %scriptpath )
 
+
     def sendmail(self, emailMsg):
         try:
             if(not self.loggedin):
@@ -42,7 +45,8 @@ Call 'croncoat --ini' for an example layout of the .ini file" %scriptpath )
             print "sendmail exception: %s" %str(e)
             if self.cfg.get('Mail', 'use_sendmailfallback', False):
                 from subprocess import Popen, PIPE
-                sm_proc = Popen(["/usr/sbin/sendmail", "-t", "-oi"], stdin=PIPE)
+                sendmailpath = self.cfg.get('Mail', 'sendmail_path')
+                sm_proc = Popen([sendmailpath, "-t", "-oi"], stdin=PIPE)
                 sm_proc.communicate(emailMsg.as_string())
                 print "(sendmail fallback used)"
 


### PR DESCRIPTION
I got error '[Errno 113] No route to host' with smtp_ssl because of a bug in OpenSSL 1.0.1e-fips (centos 6.6) which made an ssl connection to my smtp server impossible. I haven't succeeded in compiling python with gnu-tls or polarssl, and this workaround suites me best although the emails are not dkim/dmarc compliant. 
